### PR TITLE
Minor display updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
       - develop
 
 env:
-  firmware_version: '0.78.1'
+  firmware_version: '0.79.1'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 env:
-  firmware_version: '0.78.1'
+  firmware_version: '0.79.1'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build](https://github.com/xtruan/FlipBIP/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/xtruan/FlipBIP/actions/workflows/build.yml)
 
 ## Crypto toolkit for Flipper Zero
-- Built against `0.78.1` Flipper Zero firmware release
+- Built against `0.79.1` Flipper Zero firmware release
 - Using Trezor crypto libs from `core/v2.5.3` release
 - Included in [RogueMaster Custom Firmware](https://github.com/RogueMaster/flipperzero-firmware-wPlugins)
 

--- a/application.fam
+++ b/application.fam
@@ -3,7 +3,6 @@ App(
     name="FlipBIP Crypto Tool",
     apptype=FlipperAppType.EXTERNAL,
     entry_point="flipbip_app",
-    cdefines=["APP_FLIPBIP"],
     requires=[
         "gui",
     ],
@@ -16,7 +15,7 @@ App(
             name="crypto",
         ),
     ],
-    fap_category="Misc",
+    fap_category="Tools",
     fap_description="Crypto toolkit for Flipper",
     fap_author="Struan Clark (xtruan)",
     fap_weburl="https://github.com/xtruan/FlipBIP",

--- a/flipbip.h
+++ b/flipbip.h
@@ -15,7 +15,7 @@
 #include "views/flipbip_startscreen.h"
 #include "views/flipbip_scene_1.h"
 
-#define FLIPBIP_VERSION "v0.0.7"
+#define FLIPBIP_VERSION "v0.0.8"
 
 #define COIN_BTC 0
 #define COIN_DOGE 3

--- a/helpers/flipbip_file.c
+++ b/helpers/flipbip_file.c
@@ -40,8 +40,8 @@ bool flipbip_load_file(char* settings, const FlipBipFile file_type, const char* 
     } else if(file_type == FlipBipFileDat) {
         path = FLIPBIP_DAT_PATH;
     } else {
-        char path_buf[32] = {0};
-        strcpy(path_buf, FLIPBIP_APP_BASE_FOLDER);
+        char path_buf[FILE_MAX_PATH_LEN] = {0};
+        strcpy(path_buf, FLIPBIP_APP_BASE_FOLDER); // 22
         strcpy(path_buf + strlen(path_buf), "/");
         strcpy(path_buf + strlen(path_buf), file_name);
         path = path_buf;
@@ -95,8 +95,8 @@ bool flipbip_has_file(const FlipBipFile file_type, const char* file_name, const 
     } else if(file_type == FlipBipFileDat) {
         path = FLIPBIP_DAT_PATH;
     } else {
-        char path_buf[32] = {0};
-        strcpy(path_buf, FLIPBIP_APP_BASE_FOLDER);
+        char path_buf[FILE_MAX_PATH_LEN] = {0};
+        strcpy(path_buf, FLIPBIP_APP_BASE_FOLDER); // 22
         strcpy(path_buf + strlen(path_buf), "/");
         strcpy(path_buf + strlen(path_buf), file_name);
         path = path_buf;

--- a/helpers/flipbip_file.c
+++ b/helpers/flipbip_file.c
@@ -28,6 +28,7 @@ const char* TEXT_QRFILE = "Filetype: QRCode\n"
 #define FILE_KLEN 256
 #define FILE_SLEN 512
 #define FILE_MAX_PATH_LEN 48
+#define FILE_MAX_QRFILE_CONTENT 90
 const char* FILE_HSTR = "fb01";
 const char* FILE_K1 = "fb0131d5cf688221c109163908ebe51debb46227c6cc8b37641910833222772a"
                       "baefe6d9ceb651842260e0d1e05e3b90d15e7d5ffaaabc0207bf200a117793a2";
@@ -178,7 +179,7 @@ bool flipbip_save_qrfile(
     const char* qr_msg_prefix,
     const char* qr_msg_content,
     const char* file_name) {
-    char qr_buf[90] = {0};
+    char qr_buf[FILE_MAX_QRFILE_CONTENT] = {0};
     strcpy(qr_buf, TEXT_QRFILE);
     strcpy(qr_buf + strlen(qr_buf), qr_msg_prefix);
     strcpy(qr_buf + strlen(qr_buf), qr_msg_content);

--- a/views/flipbip_scene_1.c
+++ b/views/flipbip_scene_1.c
@@ -279,7 +279,11 @@ void flipbip_scene_1_draw(Canvas* canvas, FlipBipScene1Model* model) {
     } else if(model->page == PAGE_XPUB_EXTD) {
         flipbip_scene_1_draw_generic(model->xpub_extended, 20);
     } else if(model->page >= PAGE_ADDR_BEGIN && model->page <= PAGE_ADDR_END) {
-        flipbip_scene_1_draw_generic(model->recv_addresses[model->page - PAGE_ADDR_BEGIN], 12);
+        uint32_t line_len = 12;
+        if(model->coin == FlipBipCoinETH60) {
+            line_len = 14;
+        }
+        flipbip_scene_1_draw_generic(model->recv_addresses[model->page - PAGE_ADDR_BEGIN], line_len);
     }
 
     if(model->page == PAGE_LOADING) {

--- a/views/flipbip_scene_1.c
+++ b/views/flipbip_scene_1.c
@@ -49,7 +49,7 @@ const char* TEXT_INFO = "-Scroll pages with up/down-"
                         "p6,7)  xprv/xpub Extnd Keys"
                         "p8+)    Receive Addresses  ";
 
-#define TEXT_SAVE_QR "Save QR"
+// #define TEXT_SAVE_QR "Save QR"
 #define TEXT_QRFILE_EXT ".qrcode" // 7 chars + 1 null
 
 // bip44_coin, xprv_version, xpub_version, addr_version, wif_version, addr_format


### PR DESCRIPTION
- Bump to version v0.0.8
- Bump FlipperZero compile version to v0.79.1
- Move from Misc to Tools category
- Adjust ETH to display on 3 lines
- Fix some file buffer sizes
- Remove CDEFINES from `application.fam`